### PR TITLE
[FIX] mail: fix access permission error in case create_user_id is only in one of companies in multiple company configuration

### DIFF
--- a/addons/mail/data/mail_data.xml
+++ b/addons/mail/data/mail_data.xml
@@ -329,7 +329,7 @@
 
         <template id="message_activity_assigned">
 <div style="margin: 0px; padding: 0px; font-size: 13px;">
-    <span t-field="activity.create_user_id.name"/> assigned you an activity <span t-field="activity.activity_type_id.name"/>
+    <span t-field="activity.sudo().create_user_id.name"/> assigned you an activity <span t-field="activity.activity_type_id.name"/>
     <t t-if="activity.summary">(<span t-field="activity.summary"/>)</t>
     on <span t-field="activity.res_name"/>
     to close for <span t-field="activity.date_deadline"/>.<br />


### PR DESCRIPTION
* Description of the issue/feature this PR addresses:
In multiple company mode, `message_activity_assigned` template is called in company which does not include  `create_user_id`. It results in access permission error.
* Current behavior before PR:
Access permission error
* Desired behavior after PR is merged:
No error occurred
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
